### PR TITLE
escape backslash

### DIFF
--- a/modules/kubernetes-addons/argocd/variables.tf
+++ b/modules/kubernetes-addons/argocd/variables.tf
@@ -10,7 +10,7 @@ variable "applications" {
   default     = {}
 
   validation {
-    condition     = alltrue([for k, v in var.applications : length(regexall("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", k)) > 0])
+    condition     = alltrue([for k, v in var.applications : length(regexall("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", k)) > 0])
     error_message = "All ArgoCD application config keys must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
   }
 }


### PR DESCRIPTION
## :bangbang: PLEASE READ THIS FIRST :bangbang:

The direction for EKS Blueprints will soon shift from providing an all-encompassing, monolithic "framework" and instead focus more on how users can organize a set of modular components to create the desired solution on Amazon EKS. We have updated the [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to show how we use the https://github.com/terraform-aws-modules/terraform-aws-eks for EKS cluster and node group creation. We will not be accepting any PRs that apply to EKS cluster or node group creation process. Any such PR may be closed by the maintainers.

We are hitting also the pause button on new add-on creations at this time until a future roadmap for add-ons is finalized. Please do not submit new add-on PRs. Any such PR may be closed by the maintainers.

Please track progress, learn what's new and how the migration path would look like to upgrade your current Terraform deployments. We welcome the EKS Blueprints community to continue the discussion in issue https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1421

### What does this PR do?

This fixes a typo in a recent change to the argocd addon that stopped it from working.  you have to escape the backslash before the dot.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
